### PR TITLE
Enable immediate display of network maps when selecting artists

### DIFF
--- a/client/src/components/search-interface.tsx
+++ b/client/src/components/search-interface.tsx
@@ -65,12 +65,36 @@ function SearchInterface({ onNetworkData, showNetworkView, clearSearch, onLoadin
 
   useEffect(() => {
     if (onSearchFunction) {
-      onSearchFunction((artistName: string) => {
+      onSearchFunction(async (artistName: string) => {
+        console.log(`🔍 [Search Interface] Triggered search for: ${artistName}`);
         setSearchQuery(artistName);
-        handleSearch();
+        
+        // Trigger search immediately with the new artist name
+        try {
+          setIsLoading(true);
+          onLoadingChange?.(true);
+          
+          const data = await fetchNetworkData(artistName.trim());
+          onNetworkData(data);
+          
+          toast({
+            title: "Network Generated",
+            description: `Found collaboration network for ${artistName}`,
+          });
+        } catch (error) {
+          console.error(`❌ [Search Interface] Error searching for ${artistName}:`, error);
+          toast({
+            title: "Error",
+            description: error instanceof Error ? error.message : "Failed to fetch network data",
+            variant: "destructive",
+          });
+        } finally {
+          setIsLoading(false);
+          onLoadingChange?.(false);
+        }
       });
     }
-  }, [onSearchFunction, handleSearch]);
+  }, [onSearchFunction, onNetworkData, onLoadingChange, toast]);
 
   return (
     <>


### PR DESCRIPTION
Updates `onSearchFunction` to immediately display network maps upon artist selection.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 54a0bd54-c8c3-4e56-a709-6a1a042d836b
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/55616c08-7e40-44db-b48d-673d54bd78e3/2ecb6b8d-ab24-4295-8946-cba5633198c1.jpg